### PR TITLE
Fix: recover a botched deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ RUN_CMD:=docker run --rm -it \
 	--env MOLECULE_NO_LOG=no \
 	$(IMAGE)
 
+.PHONY: lint
+lint:
+	docker run -it --rm -v $(CURDIR):/work -w /work alpine/flake8:3.5.0 ./library
+
 .PHONY: test
 test:
 	$(RUN_CMD) molecule test $(OPTS)

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,23 @@ SHELL=/bin/bash
 
 IMAGE:=quay.io/ansible/molecule:3.0.4
 ANSIBLE_ROLE:=ansible-docker-plugin-loki
+MOLECULE_NO_LOG?=no
 OPTS?=--all
 
 RUN_CMD:=docker run --rm -it \
-	-v "$(CURDIR)":/tmp/$(ANSIBLE_ROLE):ro \
-	-v /var/run/docker.sock:/var/run/docker.sock \
-	-w /tmp/$(ANSIBLE_ROLE) \
-	--env MOLECULE_NO_LOG=no \
-	$(IMAGE)
+	-v "$(CURDIR)":/tmp/$(ANSIBLE_ROLE) \
+	-w /tmp/$(ANSIBLE_ROLE)
 
-.PHONY: lint
-lint:
-	docker run -it --rm -v $(CURDIR):/work -w /work alpine/flake8:3.5.0 ./library
+.PHONY: flake8
+flake8:
+	$(RUN_CMD) alpine/flake8:3.5.0 ./library
 
 .PHONY: test
 test:
-	$(RUN_CMD) molecule test $(OPTS)
+	$(RUN_CMD) \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	--env MOLECULE_NO_LOG=$(MOLECULE_NO_LOG) \
+	$(IMAGE) molecule test $(OPTS)
 
 .PHONY: shell
 shell:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,17 @@ IMAGE:=quay.io/ansible/molecule:3.0.4
 ANSIBLE_ROLE:=ansible-docker-plugin-loki
 OPTS?=--all
 
+RUN_CMD:=docker run --rm -it \
+	-v "$(CURDIR)":/tmp/$(ANSIBLE_ROLE):ro \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	-w /tmp/$(ANSIBLE_ROLE) \
+	--env MOLECULE_NO_LOG=no \
+	$(IMAGE)
+
 .PHONY: test
 test:
-	docker run --rm -it \
-		-v "$(CURDIR)":/tmp/$(ANSIBLE_ROLE):ro \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-w /tmp/$(ANSIBLE_ROLE) \
-		--env MOLECULE_NO_LOG=no \
-		$(IMAGE) \
-		molecule test $(OPTS)
+	$(RUN_CMD) molecule test $(OPTS)
+
+.PHONY: shell
+shell:
+	$(RUN_CMD) sh

--- a/README.md
+++ b/README.md
@@ -8,14 +8,8 @@ Configuration in `daemon.json` is not part of this role, please see [the officia
 Requirements
 ------------
 
-Installed by this role:
-
- - cURL
- - jq
-
-Not installed by this role:
-
- - Docker
+  - [docker/docker-py](https://pypi.org/project/docker/)
+  - dockerd, e.g. via [atosatto/dockerswarm](https://github.com/atosatto/ansible-dockerswarm/)
 
 Role Variables
 --------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: restart docker
-  systemd:
+  service:
     name: "{{ docker_loki_docker_unit }}"
     state: restarted

--- a/library/loki_info.py
+++ b/library/loki_info.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2021, Planetary Quantum GmbH <oss@planetary-quantum.com>
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# ansible dependencies
+from ansible.module_utils.basic import AnsibleModule
+
+# code dependencies
+import docker
+
+
+def run_module():
+    module_args = dict(
+        name=dict(type='str', required=True)
+    )
+
+    result = dict(
+        changed=False,
+        name='',
+        disabled=False,
+        installed=False,
+        ref='',
+        version='',
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if module.check_mode:
+        module.exit_json(**result)
+
+    result['name'] = module.params['name']
+
+    client = docker.from_env()
+
+    try:
+        plugin = client.plugins.get(module.params['name'])
+        result['installed'] = True
+        result['disabled'] = not plugin.enabled
+        result['ref'] = plugin.attrs['PluginReference']
+        result['version'] = result['ref'].split(':')[1]
+
+    except docker.errors.DockerException:
+        result['installed'] = False
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/library/loki_setup.py
+++ b/library/loki_setup.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2021, Planetary Quantum GmbH <oss@planetary-quantum.com>
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# ansible dependencies
+from ansible.module_utils.basic import AnsibleModule
+
+# code dependencies
+import docker
+
+
+def _extract_version(attrs):
+    return attrs['PluginReference'].split(':')[1]
+
+
+def _install(name, version, client, result):
+    try:
+        plugin = client.plugins.get(name)
+        return result
+    except docker.errors.NotFound:
+        plugin = client.plugins.install(version, name)
+        if not plugin.enabled:
+            plugin.enable()
+
+        result['new_version'] = _extract_version(plugin.attrs)
+        result['changed'] = True
+        return result
+
+
+def _upgrade(name, version, client, result):
+    result['name'] = name
+
+    try:
+        plugin = client.plugins.get(name)
+    except docker.errors.NotFound:
+        raise Exception(msg=('The plugin "%s" is not installed' % name))
+
+    result['old_version'] = _extract_version(plugin.attrs)
+
+    if plugin.enabled:
+        plugin.disable()
+
+    # version contains: namespace/image:version
+    logs = plugin.upgrade(version)
+    for log_line in logs:
+        result['debug'].append({'log': log_line})
+
+    if not plugin.enabled:
+        plugin.enable()
+
+    result['debug'].append({"attrs": plugin.attrs})
+
+    result['new_version'] = _extract_version(plugin.attrs)
+
+    if result['new_version'] != result['old_version']:
+        result['changed'] = True
+
+    return result
+
+
+def run_module():
+    module_args = dict(
+        name=dict(type='str', required=True),
+        version=dict(type='str', required=True),
+        state=dict(
+            type='str',
+            default='install',
+            choices=['install', 'upgrade'])
+    )
+
+    result = dict(
+        changed=False,
+        name='',
+        new_version='',
+        old_version='',
+        debug=[]
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if module.check_mode:
+        module.exit_json(**result)
+
+    result['name'] = module.params['name']
+
+    try:
+        client = docker.from_env()
+    except docker.errors.DockerException:
+        module.fail_json(msg='Unable to create a docker-client', **result)
+
+    if module.params['state'] == "upgrade":
+        result = _upgrade(
+            module.params['name'],
+            module.params['version'],
+            client,
+            result)
+    else:
+        result = _install(
+            module.params['name'],
+            module.params['version'],
+            client,
+            result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,6 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-      - /var/cache
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,6 +4,13 @@
   pre_tasks:
     - name: Update yum
       command: yum makecache
+      args:
+        warn: false
+    - name: Install dependencies
+      yum:
+        name:
+          - curl
+          - jq
   roles:
     - role: atosatto.docker-swarm
       vars:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -23,7 +23,7 @@
         skip_cli: False
         skip_containerd: False
         skip_docker_compose: True
-        skip_docker_py: True
+        skip_docker_py: False
         skip_engine: False
         skip_group: True
         skip_swarm: True

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -14,7 +14,6 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-      - /var/cache
     groups:
       - docker_swarm_manager
     volumes:

--- a/molecule/upgrade/prepare.yml
+++ b/molecule/upgrade/prepare.yml
@@ -4,6 +4,13 @@
   pre_tasks:
     - name: Update yum
       command: yum makecache
+      args:
+        warn: false
+    - name: Install dependencies
+      yum:
+        name:
+          - curl
+          - jq
   roles:
     # Install Docker
     - role: atosatto.docker-swarm

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,7 +1,0 @@
----
-- name: Install dependencies
-  yum:
-    name:
-      - curl
-      - jq
-  when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
-- include_tasks: dependencies.yml
-
 - include_tasks: preflight.yml
 
 - include_tasks: upgrade.yml
   when:
-    - _docker_loki_version|length > 0
-    - _docker_loki_version != docker_loki_version
+    - _loki_plugin.installed
+    - _loki_plugin.version != docker_loki_version
 
 - name: Install loki docker plugin
   command: >
@@ -17,4 +15,4 @@
   register: loki_install
   changed_when: false
   when:
-    - _docker_loki_version|length == 0
+    - not _loki_plugin.installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,12 +7,15 @@
     - _loki_plugin.version != docker_loki_version
 
 - name: Install loki docker plugin
-  command: >
-    docker plugin install
-    {{ docker_loki_image }}:{{ docker_loki_version }}
-    --alias {{ _docker_loki_alias }}
-    --grant-all-permissions
-  register: loki_install
-  changed_when: false
-  when:
-    - not _loki_plugin.installed
+  loki_setup:
+    name: "{{ _docker_loki_alias }}"
+    version: "{{ docker_loki_image }}:{{ docker_loki_version }}"
+    state: install
+  register: _loki_install
+  notify:
+    - restart docker
+  when: not _loki_plugin.installed
+
+- name: Show install
+  debug:
+    var: _loki_install

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,35 +1,47 @@
 ---
 # When _docker_loki_version is '', we assume, it's not installed
-- name: Is the Docker loki plugin installed?
-  block:
-    - name: Check version
+- name: Check version
+  shell: >
+    curl -s
+    --unix-socket /var/run/docker.sock
+    http://localhost/plugins
+    |
+    jq -r '.[]|select(.PluginReference|startswith("{{ _docker_loki_api_ref }}"))|.PluginReference'
+  register: _check_version
+  args:
+    warn: false
+  changed_when: false
+
+- name: Debug
+  debug:
+    var: _check_version
+
+- name: Set version
+  set_fact:
+    _docker_loki_version: "{{ _check_version.stdout.split(':')[1] }}"
+  when:
+    - _check_version.stdout|length > 0
+
+- name: Show version
+  debug:
+    var: _docker_loki_version
+
+- block:
+    - name: Is it disabled?
       shell: >
         curl -s
         --unix-socket /var/run/docker.sock
         http://localhost/plugins
         |
-        jq -r '.[]|select(.PluginReference|startswith("docker.io/grafana/loki-docker-driver:"))|.PluginReference'
-      register: _check_version
+        jq -r '.[]|select(.PluginReference|startswith("{{ _docker_loki_api_ref }}"))|.PluginReference'
+      register: _check_disabled
       args:
         warn: false
       changed_when: false
-
-    - name: Debug
-      debug:
-        var: _check_version
-
-    - name: Set version
+    - name: Update _docker_loki_disabled fact
       set_fact:
-        _docker_loki_version: "{{ _check_version.stdout.split(':')[1] }}"
-      when:
-        - _check_version.stdout|length > 0
-
-    - name: Set version [not installed]
-      set_fact:
-        _docker_loki_version: ""
-      when:
-        - _check_version.stdout|length == 0
-
-    - name: Show version
+        _docker_loki_disabled: "{{ _check_disabled.stdout|bool }}
+    - name: Show plugin status
       debug:
-        var: _docker_loki_version
+        var: _docker_loki_disabled
+  when: _docker_loki_version|length > 0

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,47 +1,9 @@
 ---
-# When _docker_loki_version is '', we assume, it's not installed
-- name: Check version
-  shell: >
-    curl -s
-    --unix-socket /var/run/docker.sock
-    http://localhost/plugins
-    |
-    jq -r '.[]|select(.PluginReference|startswith("{{ _docker_loki_api_ref }}"))|.PluginReference'
-  register: _check_version
-  args:
-    warn: false
-  changed_when: false
+- name: Check status quo
+  loki_info:
+    name: "{{ _docker_loki_alias }}"
+  register: _loki_plugin
 
 - name: Debug
   debug:
-    var: _check_version
-
-- name: Set version
-  set_fact:
-    _docker_loki_version: "{{ _check_version.stdout.split(':')[1] }}"
-  when:
-    - _check_version.stdout|length > 0
-
-- name: Show version
-  debug:
-    var: _docker_loki_version
-
-- block:
-    - name: Is it disabled?
-      shell: >
-        curl -s
-        --unix-socket /var/run/docker.sock
-        http://localhost/plugins
-        |
-        jq -r '.[]|select(.PluginReference|startswith("{{ _docker_loki_api_ref }}"))|.PluginReference'
-      register: _check_disabled
-      args:
-        warn: false
-      changed_when: false
-    - name: Update _docker_loki_disabled fact
-      set_fact:
-        _docker_loki_disabled: "{{ _check_disabled.stdout|bool }}
-    - name: Show plugin status
-      debug:
-        var: _docker_loki_disabled
-  when: _docker_loki_version|length > 0
+    var: _loki_plugin

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -1,27 +1,17 @@
 ---
-- name: Disable loki plugin
-  command: "docker plugin disable --force {{ _docker_loki_alias }}"
-  when: not _docker_loki_disabled
-  args:
-    warn: false
+- name: Show what we will do
+  debug:
+    msg: "{{ docker_loki_image }}:{{ docker_loki_version }}"
 
-- name: Upgrade loki plugin
-  command: >
-    docker plugin upgrade
-    --grant-all-permissions
-    --skip-remote-check
-    {{ _docker_loki_alias }}
-    {{ docker_loki_image }}:{{ docker_loki_version }}
-  args:
-    warn: false
+- name: Upgrade
+  loki_setup:
+    name: "{{ _docker_loki_alias }}"
+    version: "{{ docker_loki_image }}:{{ docker_loki_version }}"
+    state: upgrade
+  register: _loki_upgrade
   notify:
     - restart docker
-  tags:
-    - skip_ansible_lint
 
-- name: Enable loki plugin
-  command: "docker plugin enable {{ _docker_loki_alias }}"
-  args:
-    warn: false
-  tags:
-    - skip_ansible_lint
+- name: Show upgrade
+  debug:
+    var: _loki_upgrade

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -1,14 +1,15 @@
 ---
 - name: Disable loki plugin
   command: "docker plugin disable --force {{ _docker_loki_alias }}"
+  when: not _docker_loki_disabled
   args:
     warn: false
-  tags:
-    - skip_ansible_lint
+
 - name: Upgrade loki plugin
   command: >
     docker plugin upgrade
-    --grant-all-permissions --skip-remote-check
+    --grant-all-permissions
+    --skip-remote-check
     {{ _docker_loki_alias }}
     {{ docker_loki_image }}:{{ docker_loki_version }}
   args:
@@ -17,6 +18,7 @@
     - restart docker
   tags:
     - skip_ansible_lint
+
 - name: Enable loki plugin
   command: "docker plugin enable {{ _docker_loki_alias }}"
   args:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,3 +3,6 @@
 # A fluent version is needed to be able to run an upgrade
 # and then not get confused about the installed version.
 _docker_loki_alias: loki:latest
+_docker_loki_api_ref: "docker.io/grafana/loki-docker-driver:"
+_docker_loki_disabled: false
+_docker_loki_version: ""

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,3 @@
 # A fluent version is needed to be able to run an upgrade
 # and then not get confused about the installed version.
 _docker_loki_alias: loki:latest
-_docker_loki_api_ref: "docker.io/grafana/loki-docker-driver:"
-_docker_loki_disabled: false
-_docker_loki_version: ""


### PR DESCRIPTION
- docker plugin disable errors hard when a plugin is (already) disabled
- attempt to gather "fact" about plugin status and disable based on that
- refacts some "set_facts" into variables

---

I added two modules instead of the odd `shell` / `command` code:

 - `loki_info` (as a "fact" gathering module)
 - `loki_setup` for installation and upgrade of the plugin
 - both use the (hopefully) installed docker-sdk to do their work
 - this removes `jq` and `curl` utilities as runtime dependencies (though still needed in tests)
